### PR TITLE
remove view, use reference

### DIFF
--- a/include/xElastoPlasticQPot/Cartesian2d_Matrix.hpp
+++ b/include/xElastoPlasticQPot/Cartesian2d_Matrix.hpp
@@ -376,7 +376,7 @@ inline void Matrix::energy(const xt::xtensor<double,4> &a_Eps, xt::xtensor<doubl
       {
         // - alias
         auto Eps    = xt::view(a_Eps   , e, k);
-        auto energy = xt::view(a_energy, e, k);
+        auto& energy = a_energy(e, k);
         // - compute
         switch ( m_type(e,k) )
         {


### PR DESCRIPTION
This is important, because otherwise the assignment is done via the `xexpression` mechanism which does some "unnecessary" work.

I also saw a good speed up when using noalias on the view, so if you really want to use a view, then that would be necessary. But IMO for accessing scalars it's better to be explicit.

We could, at some point, think about making it fast to assign to a scalar view but it seems like premature optimization and it would require a bit of code ... 